### PR TITLE
[feat]기본 페이지 구현 및 기본 store 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+node_modules

--- a/global.d.ts
+++ b/global.d.ts
@@ -1,0 +1,4 @@
+declare module '*.scss' {
+    const content: { [className: string]: string };
+    export default content;
+}

--- a/package.json
+++ b/package.json
@@ -6,6 +6,8 @@
     "@types/react": "^19.0.6",
     "@types/react-dom": "^19.0.3",
     "cra-template-typescript": "1.2.0",
+    "mobx": "^6.13.5",
+    "mobx-react-lite": "^4.1.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-scripts": "5.0.1",
@@ -40,6 +42,7 @@
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.1.0",
     "@testing-library/user-event": "^14.5.2",
-    "@types/jest": "^29.5.14"
+    "@types/jest": "^29.5.14",
+    "sass": "^1.83.4"
   }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,12 +1,30 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import './App.css';
 import MainPageComponent from './components/MainPageComponent';
+import RootStore from './store/RootStore';
+import InformationStore from './store/InformationStore';
+import StoreProvider from './store/StoreProvider';
+
+let rootStore: RootStore | undefined;
 
 function App() {
+  if (!rootStore) {
+    const informationStore = new InformationStore();
+    rootStore = {informationStore} as RootStore;
+  }
+
+  // useEffect(() => {
+  //   return () => {
+  //     rootStore = undefined;
+  //   };
+  // }, []);
+
   return (
-    <div className="App">
-      <MainPageComponent/ >
-    </div>
+    <StoreProvider value={rootStore}>
+      <div className="App">
+        <MainPageComponent />
+      </div>
+    </StoreProvider>
   );
 }
 

--- a/src/components/ContentAreasComponent.tsx
+++ b/src/components/ContentAreasComponent.tsx
@@ -1,9 +1,29 @@
-import React from "react";
+import React, { useState } from "react";
+import styles from "../styles/ContentAreasComponent.module.scss";
+import useStore from "../hooks/useStore";
+import HomePageComponent from "./HomePageComponent";
+import WeatherSearchComponent from "./WeatherSearchComponent";
 
 const ContentAreasComponent: React.FC = () => {
+    const { informationStore } = useStore();
+    const curPageNum = informationStore.getPage();
+
+    const renderPage = () => {
+        switch (curPageNum) {
+            case 0: {
+                return (<HomePageComponent />);
+            }
+            case 1: {
+                return (<WeatherSearchComponent />);
+            }
+            default:
+                break;
+        }
+    }
+
     return (
-        <div>
-            컨텐트 영역
+        <div className={styles.ContentArea}>
+            { renderPage() }
         </div>
     );
 }

--- a/src/components/HomePageComponent.tsx
+++ b/src/components/HomePageComponent.tsx
@@ -1,0 +1,11 @@
+import React from "react";
+
+const HomePageComponent: React.FC = () => {
+    return (
+        <div>
+            여기는 홈 페이지입니다.
+        </div>
+    );
+}
+
+export default HomePageComponent;

--- a/src/components/MainPageComponent.tsx
+++ b/src/components/MainPageComponent.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import MenuBarComponent from "./MenuBarComponents";
 import ContentAreasComponent from "./ContentAreasComponent";
 import StatusBarComponent from "./StatusBarComponent";
+import NavigatorComponent from "./NavigatorComponent";
 
 const MainPageComponent: React.FC = () => {
     return (
@@ -9,6 +10,7 @@ const MainPageComponent: React.FC = () => {
             <MenuBarComponent />
             <ContentAreasComponent />
             <StatusBarComponent />
+            <NavigatorComponent />
         </div>
     );
 };

--- a/src/components/MenuBarComponents.tsx
+++ b/src/components/MenuBarComponents.tsx
@@ -1,16 +1,17 @@
 import React from "react";
+import styles from "../styles/MenuBarComponent.module.scss";
 
 const MenuBarComponent: React.FC = () => {
-    const menu_list = ['홈', '날씨', '주기'];
+    const menu_list = ['홈', '날씨'];
 
     const renderMenuList = () => {
         return menu_list.map((item, index) => (
-            <div key={index}>{item}</div>
+            <div className={styles.MenuBarItem} key={index}>{item}</div>
         ))
     };
 
     return (
-        <div>
+        <div className={styles.MenuBar}>
             {renderMenuList()}
         </div>
     );

--- a/src/components/NavigatorComponent.tsx
+++ b/src/components/NavigatorComponent.tsx
@@ -1,0 +1,12 @@
+import React from "react";
+import styles from "../styles/NavigatorComponent.module.scss";
+
+const NavigatorComponent = () => {
+    return (
+        <div className={styles.navi}>
+            navigator
+        </div>
+    );
+}
+
+export default NavigatorComponent;

--- a/src/components/StatusBarComponent.tsx
+++ b/src/components/StatusBarComponent.tsx
@@ -1,8 +1,9 @@
 import React from "react";
+import styles from "../styles/StatusBarComponent.module.scss";
 
 const StatusBarComponent: React.FC = () => {
     return (
-        <div>
+        <div className={styles.statusBar}>
             스테이터스바
         </div>
     );

--- a/src/components/WeatherSearchComponent.tsx
+++ b/src/components/WeatherSearchComponent.tsx
@@ -1,0 +1,11 @@
+import React from "react";
+
+const WeatherSearchComponent: React.FC = () => {
+    return (
+        <div>
+            날씨 찾기 페이지입니다.
+        </div>
+    );
+}
+
+export default WeatherSearchComponent;

--- a/src/hooks/useStore.ts
+++ b/src/hooks/useStore.ts
@@ -1,0 +1,7 @@
+import { useContext } from "react";
+import { StoreContext } from "../store/StoreProvider";
+import RootStore from "../store/RootStore";
+
+const useStore = (): RootStore => useContext(StoreContext);
+
+export default useStore;

--- a/src/store/InformationStore.ts
+++ b/src/store/InformationStore.ts
@@ -1,0 +1,33 @@
+import { makeObservable } from "mobx";
+
+// 프로젝트에서 전역으로 관리할 변수들을 저장하는 store
+// 각 페이지 별 필요한 정보들을 각각의 context로 분리해서 관리할 필요가 있을지 추후 점검 후 필요시 변경하자
+class InformationStore {
+    private page: number;
+    
+    private city: string | undefined;
+    
+    public constructor() {
+        makeObservable(this);
+        this.city = undefined;
+        this.page = 0;
+    }
+
+    public getPage(): number {
+        return this.page;
+    }
+
+    public setPage(idx: number) {
+        this.page = idx;
+    }
+
+    public getCity(): string | undefined {
+        return this.city;
+    }
+
+    public setCity(name: string) {
+        this.city = name;
+    }
+}
+
+export default InformationStore;

--- a/src/store/RootStore.ts
+++ b/src/store/RootStore.ts
@@ -1,0 +1,6 @@
+import InformationStore from "./InformationStore";
+
+// 전역으로 관리할 state를 담고 있을 객체
+export default interface RootStore {
+    informationStore: InformationStore;
+}

--- a/src/store/StoreProvider.ts
+++ b/src/store/StoreProvider.ts
@@ -1,0 +1,7 @@
+import { createContext } from "react";
+import RootStore from "./RootStore";
+
+export const StoreContext = createContext<RootStore>({} as RootStore);
+const StoreProvider = StoreContext.Provider;
+
+export default StoreProvider;

--- a/src/styles/ContentAreasComponent.module.scss
+++ b/src/styles/ContentAreasComponent.module.scss
@@ -1,0 +1,4 @@
+.ContentArea {
+    min-height: 850px;
+    border: 1px solid blue;
+}

--- a/src/styles/MenuBarComponent.module.scss
+++ b/src/styles/MenuBarComponent.module.scss
@@ -1,0 +1,13 @@
+.MenuBar {
+    display:flex;
+    border: 1px solid black;
+}
+
+.MenuBarItem {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    border: 1px solid black;
+    width: 100px;
+    height: 30px;
+}

--- a/src/styles/NavigatorComponent.module.scss
+++ b/src/styles/NavigatorComponent.module.scss
@@ -1,0 +1,8 @@
+.navi {
+    position: fixed;
+    width: 100px;
+    height: 100px;
+    top: 50%;
+    left: 90%;
+    border: 1px solid yellow;
+}

--- a/src/styles/StatusBarComponent.module.scss
+++ b/src/styles/StatusBarComponent.module.scss
@@ -1,0 +1,4 @@
+.statusBar {
+    border: 1px solid red;
+    height: 65px;
+}


### PR DESCRIPTION
1. 기본 페이지 구성 구현 완료 1-1. 메뉴바 - 컨텐츠 - footer / navigator 구조 구현
1-2. 홈 페이지 component 틀 구현
1-3. 날씨 찾기 component 틀 구현
2. 기본 store 구현 완료 2-1. 전역으로 관리할 state를 위한 store 구현
2-2. createContext를 이용하여 state를 전달하도록 처리(RootStore) 2-3. RootStore 내에 InformationStore를 생성하여 정보들을 IS에서 관리하도록 처리 2-4. RootStore 내에 다른 내용이 저장될 필요가 없다면 IS 자체를 RootStore로 변경하는 작업 필요 2-5. IS 내에 저장하는 정보들을 각 페이지 별로 분리할 필요가 있을지 추후 판단 필요