### PR TITLE
[bugfix] 게시글 삭제 동작이 제대로 이루어지지 않는 문제

### DIFF
--- a/server/server.ts
+++ b/server/server.ts
@@ -133,7 +133,7 @@ app.get("/userInfo/:userId", (req: Request, res: Response) => {
 // 게시글 삭제 
 app.post("/deletePost/:postId", (req: Request, res: Response) => {
     try {
-        const postId = req.params.postId;
+        const postId = parseInt(req.params.postId);
         const users = readDataFile("user");
         users.map((user) => {
             if (user.heart.includes(postId)) {
@@ -146,12 +146,14 @@ app.post("/deletePost/:postId", (req: Request, res: Response) => {
         writeDataFile(users, "user");
 
         const posts = readDataFile();
-        const deletePost = posts.find(post => post.postId === postId);
-        if (deletePost) {
-            posts.splice(deletePost, 1);
+        const deletePostIndex = posts.findIndex(post => post.postId === postId);
+        if (deletePostIndex !== -1) {
+            posts.splice(deletePostIndex, 1);
+            writeDataFile(posts);
+            res.status(201).json(posts);
+        } else {
+            res.status(404).send("게시글을 찾을 수 없습니다.");
         }
-        writeDataFile(posts);
-        res.status(201).json(posts);
     } catch (error) {
         console.log("게시글 삭제 업데이트 중 오류: ", error);
         res.status(500).send("게시글 삭제 업데이트 실패");

--- a/src/store/InformationStore.ts
+++ b/src/store/InformationStore.ts
@@ -1,4 +1,4 @@
-import { action, makeObservable, observable } from "mobx";
+import { action, makeObservable, observable, runInAction } from "mobx";
 import { boundMethod } from 'autobind-decorator';
 
 // 프로젝트에서 전역으로 관리할 변수들을 저장하는 store
@@ -26,7 +26,7 @@ class InformationStore {
 
     @boundMethod
     public setPage(idx: number) {
-        this.page = idx;
+        runInAction(() => this.page = idx);
     }
 
     @boundMethod
@@ -36,7 +36,7 @@ class InformationStore {
 
     @boundMethod
     public setCity(name: string) {
-        this.city = name;
+        runInAction(() => this.city = name);
     }
 
     @boundMethod

--- a/src/store/UserStore.ts
+++ b/src/store/UserStore.ts
@@ -20,13 +20,13 @@ class UserStore {
     @observable
     private userLevel : UserLevel;
 
-    @observable.shallow
+    @observable
     private heartList: number[];
 
-    @observable.shallow
+    @observable
     private bookmarkList: number[];
 
-    @observable.shallow
+    @observable
     private favoriteList: string[];
 
     constructor() {
@@ -81,14 +81,16 @@ class UserStore {
 
     @boundMethod
     public addHeart(postid: number): void {
-        this.heartList.push(postid);
+        runInAction(() => this.heartList.push(postid));
     }
 
     @boundMethod
     public deleteHeart(postid: number): void {
-        const idx = this.heartList.indexOf(postid);
-        if (idx !== -1)
-            this.heartList.splice(idx, 1);
+        runInAction(() => {
+            const idx = this.heartList.indexOf(postid);
+            if (idx !== -1)
+                this.heartList.splice(idx, 1);
+        });
     }
 
     @boundMethod
@@ -98,14 +100,16 @@ class UserStore {
 
     @boundMethod
     public addBookmark(postId: number) {
-        this.bookmarkList.push(postId);
+        runInAction(() => this.bookmarkList.push(postId));
     }
 
     @boundMethod
     public deleteBookmark(postId: number) {
-        const idx = this.bookmarkList.indexOf(postId);
-        if (idx !== -1)
-            this.bookmarkList.splice(idx, 1);
+        runInAction(() => {
+            const idx = this.bookmarkList.indexOf(postId);
+            if (idx !== -1)
+                this.bookmarkList.splice(idx, 1);
+        });
     }
 
     @boundMethod
@@ -115,21 +119,25 @@ class UserStore {
 
     @boundMethod
     public addFavorite(menu: string) {
-        this.favoriteList.push(menu);
+        runInAction(() => this.favoriteList.push(menu));
     }
 
     @boundMethod
     public deleteFavorite(menu: string) {
-        const idx = this.favoriteList.indexOf(menu);
-        if (idx !== -1)
-            this.favoriteList.splice(idx, 1);
+        runInAction(() => {
+            const idx = this.favoriteList.indexOf(menu);
+            if (idx !== -1)
+                this.favoriteList.splice(idx, 1);
+        });
     }
 
     @boundMethod
     public deleteFavorites(items: string[]): void {
-        const len = items.length;
-        const deleteLookUp = len > 10 ? new Set(items) : items;
-        this.favoriteList = this.favoriteList.filter(item => len > 10 ? !(deleteLookUp as Set<string>).has(item) : !(deleteLookUp as string[]).includes(item));
+        runInAction(() => {
+            const len = items.length;
+            const deleteLookUp = len > 10 ? new Set(items) : items;
+            this.favoriteList = this.favoriteList.filter(item => len > 10 ? !(deleteLookUp as Set<string>).has(item) : !(deleteLookUp as string[]).includes(item));
+        });
     }
 }
 


### PR DESCRIPTION
원인:
1. 구현한 api에서 인자로 받은 값은 string인데 int로 변환하지 않고 int로 사용
2. 제거할 post를 찾고 posts에서 해당 post만 제거하는 과정에서 잘못제거하고 있어서 문제 발생
3. 서버로부터 새로운 posts를 await을 통해서 받아오고 이후 dispatch를 통해 state를 업데이트하는데 await 동작이 다 끝나기 전에 dispatch 로직이 수행됨. 이로 인해서 정상적으로 state 업데이트가 되지 않는 문제 발생. 해결:
1. parseInt로 casting하여 처리
2. slice 함수는 index를 받도록 되어 있기 때문에 해당 post의 index를 찾은 후, 이를 이용하여 slice하도록 처리
3. dispatch 함수를 setTimeOut으로 호출하여 await 동작이 끝난 후, 실행되도록 처리